### PR TITLE
Fix newline chars that create rows in CSVs

### DIFF
--- a/tdb.py
+++ b/tdb.py
@@ -630,7 +630,7 @@ class tdb():
                 row.extra.update(action_dict)
                 row.content = action
             else:
-                row.content = msg.message_content.strip('"\'')
+                row.content = msg.message_content.strip('"\'').replace("\n", " ")
 
             if msg.blob_reply:
                 replied_msg = msg


### PR DESCRIPTION
When creating timeline, messages can have newline characters '\n' that leads to multiple rows inside the CSV file.